### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-input.yaml
+++ b/.github/workflows/secret-input.yaml
@@ -12,6 +12,9 @@ on:
         required: true
         type: secret
 
+permissions:
+  contents: read
+
 jobs:
   example_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ds-jhartmann/github-action-tests/security/code-scanning/1](https://github.com/ds-jhartmann/github-action-tests/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. Since the job only reads inputs and prints/masks them, and writes to `$GITHUB_OUTPUT`, it does not need to modify repository contents, issues, or pull requests. The recommended least‑privilege baseline is to set `permissions: contents: read` at the workflow or job level; because this workflow has only one job and no other needs are shown, setting it at the workflow root is cleanest and applies to all jobs.

Concretely, in `.github/workflows/secret-input.yaml`, add a `permissions:` block near the top of the file (after the `name:` or before `jobs:`) with `contents: read`. No other code or steps need to change, and no imports or external libraries are involved. This does not change existing functionality because the job was not performing any write operations that depend on broader permissions; it only narrows the token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
